### PR TITLE
GoogleTest as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/googletest"]
+	path = third_party/googletest
+	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: cpp
 addons:
   apt:
     packages:
-      - ccache 
+      - ccache
 cache:
   apt: true
   directories:
@@ -15,24 +15,24 @@ cache:
 env:
   global:
     - DEPS_DIR="$HOME/install"
-    - CMAKE_DIR="$DEPS_DIR/cmake-3.3.2-Linux-x86_64" 
+    - CMAKE_DIR="$DEPS_DIR/cmake-3.5.2-Linux-x86_64"
     - CMAKE="$CMAKE_DIR/bin/cmake"
     - JSON_DIR="$DEPS_DIR/json-c-0.11"
-    - JSON_LIB="$JSON_DIR/install" 
+    - JSON_LIB="$JSON_DIR/install"
     - JSON_INCLUDE_DIR="$JSON_DIR"
     - LCOV_DIR="$DEPS_DIR/lcov-1.11"
     - LCOV="$LCOV_DIR/bin/lcov"
-    - GMOCK_DIR="$DEPS_DIR/gmock-1.7.0" 
+    - GTEST_DIR="$TRAVIS_BUILD_DIR/third_party/googletest"
 
 matrix:
   include:
     - os: linux
-      compiler: gcc-4.9 
+      compiler: gcc-4.9
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['texlive-latex-base','gcc-4.9','g++-4.9','libpcap-dev','valgrind']
-      env: 
+      env:
         # You can not set CXX directly as Travis CI will overwrite it. You need an intermediate variable like COMPILER
         - COMPILER=g++-4.9 CXX_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage -fPIC" C_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" gcov="/usr/bin/gcov-4.9"
       fast_finish: true
@@ -42,11 +42,12 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5']
           packages: ['texlive-latex-base','clang-3.5','llvm-3.5-dev','libpcap-dev','valgrind']
-      env: 
+      env:
         - COMPILER=/usr/bin/clang++-3.5 gcov="/usr/bin/gcov-4.9"
       fast_finish: true
 
 before_install:
+  - git submodule update --init --recursive
   - uname -a
   - pwd
   - export
@@ -57,16 +58,11 @@ install:
   - gem install coveralls-lcov
   - |
     if [ ! -f "$CMAKE" ]; then
-      wget -O - --no-check-certificate https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | tar xz && cp -r cmake-3.3.2-Linux-x86_64 $DEPS_DIR
-    else 
+      wget -O - --no-check-certificate https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz | tar xz && cp -r cmake-3.5.2-Linux-x86_64 $DEPS_DIR
+    else
       echo "Using cached cmake"
     fi
   - |
-    if [ ! -f "$GMOCK_DIR/CMakeLists.txt" ]; then
-      wget -q https://googlemock.googlecode.com/files/gmock-1.7.0.zip && unzip gmock-1.7.0.zip -d $DEPS_DIR
-    else 
-      echo "Using cached gmock" 
-    fi
 
   # installing libjson-c from source because #'ondrej/php5-5.6' is disallowed source in travis-ci
   - |
@@ -90,7 +86,7 @@ before_script:
   - $LCOV --gcov-tool "/usr/bin/gcov-4.9" --directory . --zerocounters
 script:
   - mkdir debug && cd debug
-  - $CMAKE -DCMAKE_CXX_COMPILER="$COMPILER" -DCMAKE_BUILD_TYPE=DEBUG -DGMOCK_SOURCE_DIR=$GMOCK_DIR -D"CMAKE_CXX_FLAGS=$CXX_FLAGS" -DCMAKE_C_FLAGS="$C_FLAGS" -DINCLUDE_COVERAGE_INFO="true" ../
+  - $CMAKE -DCMAKE_CXX_COMPILER="$COMPILER" -DCMAKE_BUILD_TYPE=DEBUG -DGTEST_SOURCE_DIR=$GTEST_DIR -D"CMAKE_CXX_FLAGS=$CXX_FLAGS" -DCMAKE_C_FLAGS="$C_FLAGS" -DINCLUDE_COVERAGE_INFO="true" ../
   - make
   - make test
   - make documentation-pdflatex

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
-if ("${GMOCK_SOURCE_DIR}" STREQUAL "")
-    message (WARNING "GMOCK_SOURCE_DIR variable not set - unit-tests are not available. Use '-DGMOCK_SOURCE_DIR=<path_to_gmock_sources>' param for CMake")
+if ("${GTEST_SOURCE_DIR}" STREQUAL "")
+    message (WARNING "GTEST_SOURCE_DIR variable not set - unit-tests are not available. Use
+    '-DGTEST_SOURCE_DIR=<path_to_nfstrace>/third_party/googletest' param for CMake")
 else ()
     # Clang and GCC 4.9+ cause errors on GMock/GTest compilation, so we are adding following flags to suppress them
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
@@ -9,13 +10,13 @@ else ()
     set (gmock_force_shared_crt true CACHE INTERNAL "")
     set (BUILD_SHARED_LIBS false CACHE INTERNAL "")
     add_definitions (-DGTEST_HAS_PTHREAD=1) # It fixes BUG in GTests in BSD
-    add_subdirectory (${GMOCK_SOURCE_DIR} ${CMAKE_BINARY_DIR}/gmock)
+    add_subdirectory (${GTEST_SOURCE_DIR}/googlemock  ${CMAKE_BINARY_DIR}/gmock)
     set (GMOCK_LIBRARIES gmock gmock_main)
-    set (GMOCK_INCLUDE_DIRS "${GMOCK_SOURCE_DIR}/include"
-        "${GMOCK_SOURCE_DIR}/gtest/include"
-        "${GMOCK_SOURCE_DIR}")
+    set (GTEST_INCLUDE_DIRS
+        "${GTEST_SOURCE_DIR}/googletest/include"
+        "${GTEST_SOURCE_DIR}/googlemock/include")
 
-    include_directories (${CMAKE_SOURCE_DIR}/src ${GMOCK_INCLUDE_DIRS})
+    include_directories (${CMAKE_SOURCE_DIR}/src ${GTEST_INCLUDE_DIRS})
 
     add_subdirectory (utils)
     add_subdirectory (analyzers)

--- a/third_party/README
+++ b/third_party/README
@@ -1,0 +1,2 @@
+Here are third party libraries with necessary components for nfstrace.
+


### PR DESCRIPTION
added googletest as git submodule to third_party/googletest
updated travis config
- 1.     path to googletest
- 2.     cmake updated 3.3.2 -> 3.5.2 

Successful bulid https://travis-ci.org/ailyasov/nfstrace/builds/127000253