### PR TITLE
Build reproducibly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,17 @@ list (GET VERSION_LIST 2 NST_V_PATCH)
 
 set (NST_VERSION_FULL "${PROJECT_NAME} ${NST_VERSION} (${CMAKE_BUILD_TYPE})")
 
-string (TIMESTAMP COMPILATION_DATE "%Y-%m-%d")
+if (DEFINED ENV{SOURCE_DATE_EPOCH})
+  execute_process(
+    COMMAND "date" "-u" "-d" "@$ENV{SOURCE_DATE_EPOCH}" "+%Y-%m-%d"
+    OUTPUT_VARIABLE COMPILATION_DATE 
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+else ()
+  execute_process(
+    COMMAND "date" "+%Y-%m-%d"
+    OUTPUT_VARIABLE TIMESTAMP
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif ()
 
 include_directories (src)
 

--- a/src/controller/build_info.h.in
+++ b/src/controller/build_info.h.in
@@ -29,9 +29,7 @@ constexpr unsigned int NST_VERSION =
     @NST_V_MAJOR@ * 1000 + @NST_V_MINOR@ * 100 + @NST_V_PATCH@;
 
 constexpr char PROGRAM_BUILD_INFO[]=
-    "@NST_VERSION_FULL@\n"
-    "built on @CMAKE_SYSTEM@\n"
-    "by C++ compiler @CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
+    "@NST_VERSION_FULL@";
 
 constexpr char MODULES_DIRECTORY_PATH[] = "@CMAKE_INSTALL_PREFIX@/lib/nfstrace/";
 


### PR DESCRIPTION
As it is now, nfstrace [fails](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831570) to [build reproducibly](https://wiki.debian.org/ReproducibleBuilds).

This change adds support for `SOURCE_DATE_EPOCH` to enable reproducible builds.