### PR TITLE
Fix unaligned access in buffer copies.

### DIFF
--- a/src/filtration/sessions_hash.h
+++ b/src/filtration/sessions_hash.h
@@ -106,12 +106,8 @@ struct MapperImpl
 
     static inline void copy_ipv6(uint32_t dst[4], const uint8_t src[16])
     {
-        // TODO:: fix alignment of src!
-        const uint32_t* s{reinterpret_cast<const uint32_t*>(src)};
-        dst[0] = s[0];
-        dst[1] = s[1];
-        dst[2] = s[2];
-        dst[3] = s[3];
+        uint8_t* d{reinterpret_cast<uint8_t*>(dst)};
+        memcpy(d, src, sizeof(uint32_t) * 4);
     }
 
     struct IPv6PortsKeyHash


### PR DESCRIPTION
There's a TODO in the source about fixing alignment of the address being
copied.  This unaligned access is a problem on armhf with some kernel
configurations, and is generally slower even on other architectures due
to the fixups.  Just use memcpy instead which is bound to do the right
thing.

This fixes the Debian bug #[832069](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832069).