### PR TITLE
Eliminate gcc8 compiler warnings

### DIFF
--- a/src/filtration/filtration_processor.h
+++ b/src/filtration/filtration_processor.h
@@ -76,12 +76,12 @@ public:
     {
         // TODO: this code must be generalized with RPCFiltrator class
         uint32_t hdr_len{0};
-        auto     msg = reinterpret_cast<const MessageHeader* const>(info.data);
+        auto     msg = reinterpret_cast<const MessageHeader*>(info.data);
         switch(msg->type())
         {
         case MsgType::CALL:
         {
-            auto call = static_cast<const CallHeader* const>(msg);
+            auto call = static_cast<const CallHeader*>(msg);
             if(RPCValidator::check(call))
             {
                 if(NFS3Validator::check(call))
@@ -115,7 +115,7 @@ public:
         break;
         case MsgType::REPLY:
         {
-            auto reply = static_cast<const ReplyHeader* const>(msg);
+            auto reply = static_cast<const ReplyHeader*>(msg);
             if(RPCValidator::check(reply))
             {
                 // Truncate NFSv3 READ reply message to NFSv3-RW-limit

--- a/src/filtration/rpc_filtrator.h
+++ b/src/filtration/rpc_filtrator.h
@@ -80,11 +80,11 @@ public:
         const MessageHeader* const msg = rm->fragment();
         if(msg->type() == MsgType::REPLY)
         {
-            return RPCValidator::check(static_cast<const ReplyHeader* const>(msg));
+            return RPCValidator::check(static_cast<const ReplyHeader*>(msg));
         }
         if(msg->type() == MsgType::CALL)
         {
-            return RPCValidator::check(static_cast<const CallHeader* const>(msg));
+            return RPCValidator::check(static_cast<const CallHeader*>(msg));
         }
         return false;
     }
@@ -123,7 +123,7 @@ public:
         {
         case MsgType::CALL:
         {
-            auto call = static_cast<const CallHeader* const>(msg);
+            auto call = static_cast<const CallHeader*>(msg);
             if(RPCValidator::check(call))
             {
                 BaseImpl::setMsgLen(len); // length of current RPC message
@@ -164,7 +164,7 @@ public:
         break;
         case MsgType::REPLY:
         {
-            auto reply = static_cast<const ReplyHeader* const>(msg);
+            auto reply = static_cast<const ReplyHeader*>(msg);
             if(RPCValidator::check(reply))
             {
                 BaseImpl::setMsgLen(len); // length of current RPC message

--- a/src/protocols/cifs/cifs.cpp
+++ b/src/protocols/cifs/cifs.cpp
@@ -57,7 +57,7 @@ const NST::protocols::CIFSv1::MessageHeader* NST::protocols::CIFSv1::get_header(
 
 bool MessageHeader::isFlag(const Flags flag) const
 {
-    return static_cast<const uint8_t>(flag) & static_cast<const uint8_t>(flags);
+    return static_cast<uint8_t>(flag) & static_cast<uint8_t>(flags);
 }
 
 extern "C" NST_PUBLIC const char* print_cifs1_procedures(SMBv1Commands cmd_code)

--- a/src/protocols/nfs/nfs_procedure.h
+++ b/src/protocols/nfs/nfs_procedure.h
@@ -48,11 +48,11 @@ public:
     inline NFSProcedure(xdr::XDRDecoder& c, xdr::XDRDecoder& r, const Session* s)
         : parg{&arg} // set pointer to argument
         , pres{&res} // set pointer to result
+	, arg{} // zero-initializer
+	, res{}
     {
         memset(&call, 0, sizeof(call));
         memset(&reply, 0, sizeof(reply));
-        memset(&arg, 0, sizeof(arg));
-        memset(&res, 0, sizeof(res));
 
         // fill call
         if(!xdr_callmsg(c.xdr(), &call))


### PR DESCRIPTION
* Stop applying memset() to potentially non-POD types; use zero-initializers instead
* Remove meaningless consts in various static_cast()s.

These are necessary to compile with g++8.