### PR TITLE
add #include <stdexcept> in various places, where std::runtime_error …

### DIFF
--- a/analyzers/src/json/json_plugin.cpp
+++ b/analyzers/src/json/json_plugin.cpp
@@ -19,6 +19,8 @@
     along with Nfstrace.  If not, see <http://www.gnu.org/licenses/>.
 */
 //------------------------------------------------------------------------------
+#include <stdexcept>
+
 #include "api/plugin_api.h" // include plugin development definitions
 #include "json_analyzer.h"
 //------------------------------------------------------------------------------

--- a/analyzers/src/watch/nc_windows/statistics_window.cpp
+++ b/analyzers/src/watch/nc_windows/statistics_window.cpp
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include <algorithm>
 #include <numeric>
+#include <stdexcept>
 
 #include <unistd.h>
 

--- a/analyzers/src/watch/user_gui.cpp
+++ b/analyzers/src/watch/user_gui.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <exception>
 #include <iostream>
+#include <stdexcept>
 #include <system_error>
 
 #include <unistd.h>

--- a/src/analysis/analyzers.cpp
+++ b/src/analysis/analyzers.cpp
@@ -19,6 +19,8 @@
     along with Nfstrace.  If not, see <http://www.gnu.org/licenses/>.
 */
 //------------------------------------------------------------------------------
+#include <stdexcept>
+
 #include "analysis/analyzers.h"
 #include "analysis/print_analyzer.h"
 #include "utils/out.h"

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -24,6 +24,7 @@
 #define CONTROLLER_H
 //------------------------------------------------------------------------------
 #include <memory>
+#include <stdexcept>
 
 #include "analysis/analysis_manager.h"
 #include "controller/parameters.h"

--- a/src/controller/parameters.cpp
+++ b/src/controller/parameters.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include <dirent.h>
+#include <stdexcept>
 #include <unistd.h>
 
 #include "analysis/plugin.h"

--- a/src/controller/running_status.h
+++ b/src/controller/running_status.h
@@ -27,6 +27,7 @@
 #include <list>
 #include <mutex>
 #include <condition_variable>
+#include <stdexcept>
 #include <type_traits>
 
 #include "utils/noncopyable.h"

--- a/src/controller/signal_handler.cpp
+++ b/src/controller/signal_handler.cpp
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include <cerrno>
 #include <functional> // std::ref
+#include <stdexcept>
 #include <system_error>
 
 #include <pthread.h>

--- a/src/filtration/filtration_manager.cpp
+++ b/src/filtration/filtration_manager.cpp
@@ -19,6 +19,8 @@
     along with Nfstrace.  If not, see <http://www.gnu.org/licenses/>.
 */
 //------------------------------------------------------------------------------
+#include <stdexcept>
+
 #include <sys/stat.h>
 
 #include "filtration/dumping.h"

--- a/src/filtration/filtration_processor.h
+++ b/src/filtration/filtration_processor.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/protocols/xdr/xdr_decoder.h
+++ b/src/protocols/xdr/xdr_decoder.h
@@ -23,6 +23,8 @@
 #define XDR_DECODER_H
 //------------------------------------------------------------------------------
 #include <utility>
+#include <stdexcept>
+
 #include <rpc/rpc.h>
 //------------------------------------------------------------------------------
 #include "api/nfs3_types_rpcgen.h"


### PR DESCRIPTION
…is used, to fix a build failure with gcc-10