### PR TITLE
Fixes for build on Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 3.0)
-project (nfstrace)
+project (nfstrace LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # check compiler and packages ==================================================
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -25,12 +28,26 @@ find_library(PCAP_LIBRARY
              NAMES pcap
              HINTS ${PCAP_ROOT_DIR}/lib)
 
-if ("${PCAP_LIBRARY}" STREQUAL "PCAP_LIBRARY-NOTFOUND")
+if (NOT PCAP_LIBRARY)
     message (FATAL_ERROR "Could NOT find PCAP")
 endif ()
 
+# See: https://fedoraproject.org/wiki/Changes/SunRPCRemoval
+find_file (FEDORA_FOUND fedora-release PATHS /etc)
+find_file (REDHAT_FOUND redhat-release PATHS /etc)
+if (FEDORA_FOUND OR REDHAT_FOUND)
+    find_library (TIRPC_LIBRARY NAMES tirpc)
+    find_path    (TIRPC_INCLUDE NAMES rpc/rpc.h PATHS /usr/include/tirpc)
+    if (TIRPC_LIBRARY AND TIRPC_INCLUDE)
+        include_directories (${TIRPC_INCLUDE})
+        link_libraries      (${TIRPC_LIBRARY})
+    else ()
+        message (FATAL_ERROR "${TIRPC_LIBRARY} ${TIRPC_INCLUDE} is required for Fedora/RedHat")
+    endif ()
+endif ()
+
 # build application ============================================================
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pedantic -Wall -Werror -Wextra -Wno-invalid-offsetof -Wno-error=address-of-packed-member -fPIC -fvisibility=hidden")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Werror -Wextra -Wno-invalid-offsetof -fPIC -fvisibility=hidden")
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic")
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${INCLUDE_COVERAGE_INFO}")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Issues](https://img.shields.io/github/issues/epam/nfstrace.svg)](https://github.com/epam/nfstrace/issues?q=is%3Aopen+is%3Aissue)
 [![Build Status](https://img.shields.io/travis/epam/nfstrace/master.svg)](https://travis-ci.org/epam/nfstrace)
 [![Coverage Status](http://img.shields.io/coveralls/epam/nfstrace/master.svg)](https://coveralls.io/r/epam/nfstrace?branch=master)
-NFSTRACE ![NFSTRACE Logo](docs/pictures/logo64.png "Logo")
+
+![NFSTRACE Logo](docs/pictures/logo64.png "Logo") NFSTRACE
 ========
 
 `nfstrace` is an NFS and CIFS tracing/monitoring/capturing/analyzing tool.
@@ -25,7 +26,7 @@ following protocols:
 `nfstrace` has been tested on the following GNU/Linux and FreeBSD systems:
 
 - Debian Sid [packages](https://packages.debian.org/unstable/main/nfstrace) [build-logs](https://buildd.debian.org/status/logs.php?pkg=nfstrace)
-- Fedora 26
+- Fedora 34
 - OpenSUSE 13.2
 - Ubuntu 16.04 LTS
 - CentOS 7

--- a/analyzers/src/watch/watch_analyzer.cpp
+++ b/analyzers/src/watch/watch_analyzer.cpp
@@ -234,7 +234,7 @@ void WatchAnalyzer::get_dir_delegation40(const RPCProcedure* proc,
                                          const struct NFS4::GET_DIR_DELEGATION4args*,
                                          const struct NFS4::GET_DIR_DELEGATION4res* res) { if (res) { account40_op(proc, ProcEnumNFS4::NFSProcedure::GET_DIR_DELEGATION); } }
 void WatchAnalyzer::illegal40(const RPCProcedure* proc,
-                              const struct NFS4::ILLEGAL4res* res) { if (res) { account40_op(proc, ProcEnumNFS4::NFSProcedure::ILLEGAL); } }
+                              const struct NFS4::ILLEGAL4res* res) { if (res) { account40_op(proc, /*ProcEnumNFS4::NFSProcedure::ILLEGAL is mapped to 2 index*/ static_cast<ProcEnumNFS4::NFSProcedure>(2)); } }
 
 // NFSv4.1 procedures
 
@@ -406,7 +406,7 @@ void WatchAnalyzer::reclaim_complete41(const RPCProcedure* proc,
                                        const struct NFS41::RECLAIM_COMPLETE4args*,
                                        const struct NFS41::RECLAIM_COMPLETE4res* res) { if (res) { account41_op(proc, ProcEnumNFS41::NFSProcedure::RECLAIM_COMPLETE); } }
 void WatchAnalyzer::illegal41(const RPCProcedure* proc,
-                              const struct NFS41::ILLEGAL4res* res) { if (res) { account41_op(proc, ProcEnumNFS41::NFSProcedure::ILLEGAL); } }
+                              const struct NFS41::ILLEGAL4res* res) { if (res) { account41_op(proc, /*ProcEnumNFS41::NFSProcedure::ILLEGAL is mapped to 2 index*/ static_cast<ProcEnumNFS41::NFSProcedure>(2)); } }
 // CIFS v1
 void WatchAnalyzer::createDirectorySMBv1(const SMBv1::CreateDirectoryCommand* /*cmd*/, const SMBv1::CreateDirectoryArgumentType*, const SMBv1::CreateDirectoryResultType*)
 {

--- a/src/api/session.h
+++ b/src/api/session.h
@@ -62,7 +62,8 @@ struct Session
         {
             uint8_t  addr[2][16];
             uint32_t addr_uint32[2][4];
-        } __attribute__((__packed__)) v6;
+        } v6;
+        static_assert(sizeof(v6) == 32, "unexpected sizeof");
     } ip;
 };
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,6 +4,8 @@ if ("${GTEST_SOURCE_DIR}" STREQUAL "")
 else ()
     # Clang and GCC 4.9+ cause errors on GMock/GTest compilation, so we are adding following flags to suppress them
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
+    # Suppress warnings from GCC 11
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
     endif ()


### PR DESCRIPTION
fixed build on Fedora 28+(tested on 34) by integration libtirpc as replacement for SunRPC from libc
fixed memory overrun in Watch analyzer for NFS40 and NFS41
removed -Wno-error=address-of-packed-member compiler flag
removed packed attribute from Session::IPAddress.v6 union