### PR TITLE
nfstrace: fix format string specifiers detected by ncurses-6.3

### DIFF
--- a/analyzers/src/watch/nc_windows/header_window.cpp
+++ b/analyzers/src/watch/nc_windows/header_window.cpp
@@ -75,7 +75,7 @@ void HeaderWindow::update()
     /* tm starts with 0 month and 1900 year*/
     mvwprintw(_window, HEADER::DATE_LINE, FIRST_CHAR_POS, "Date: \t %d.%d.%d \t Time: %d:%d:%d  ", t->tm_mday, t->tm_mon + 1, t->tm_year + 1900, t->tm_hour, t->tm_min, t->tm_sec);
     mvwprintw(_window, HEADER::ELAPSED_LINE, FIRST_CHAR_POS, "Elapsed time:  \t %d days; %d:%d:%d times",
-              shift_time / SECINDAY, shift_time % SECINDAY / SECINHOUR, shift_time % SECINHOUR / SECINMIN, shift_time % SECINMIN);
+              (int)(shift_time / SECINDAY), (int)(shift_time % SECINDAY / SECINHOUR), (int)(shift_time % SECINHOUR / SECINMIN), (int)(shift_time % SECINMIN));
     wrefresh(_window);
 }
 

--- a/analyzers/src/watch/nc_windows/statistics_window.cpp
+++ b/analyzers/src/watch/nc_windows/statistics_window.cpp
@@ -153,7 +153,7 @@ void StatisticsWindow::update(const ProtocolStatistic& d)
         }
         if(canWrite(line))
         {
-            mvwprintw(_window, line - (_scrollOffset.at(_activeProtocol)), FIRST_CHAR_POS + 25, "%d", m);
+            mvwprintw(_window, line - (_scrollOffset.at(_activeProtocol)), FIRST_CHAR_POS + 25, "%zu", m);
         }
         line++;
         for(unsigned int j = _activeProtocol->getGroupBegin(i); j < _activeProtocol->getGroupBegin(i + 1); j++)


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    nfstrace/analyzers/src/watch/nc_windows/header_window.cpp:77:82:
      error: format '%d' expects argument of type 'int', but argument 5 has type 'time_t' {aka 'long int'} [-Werror=format=]
       77 |     mvwprintw(_window, HEADER::ELAPSED_LINE, FIRST_CHAR_POS, "Elapsed time:  \t %d days; %d:%d:%d times",
          |                                                                                 ~^
          |                                                                                  int
          |                                                                                 %ld