### PR TITLE
analyzers: fix a couple format errors

### DIFF
--- a/analyzers/src/watch/nc_windows/header_window.cpp
+++ b/analyzers/src/watch/nc_windows/header_window.cpp
@@ -74,7 +74,7 @@ void HeaderWindow::update()
     time_t shift_time  = actual_time - _start_time;
     /* tm starts with 0 month and 1900 year*/
     mvwprintw(_window, HEADER::DATE_LINE, FIRST_CHAR_POS, "Date: \t %d.%d.%d \t Time: %d:%d:%d  ", t->tm_mday, t->tm_mon + 1, t->tm_year + 1900, t->tm_hour, t->tm_min, t->tm_sec);
-    mvwprintw(_window, HEADER::ELAPSED_LINE, FIRST_CHAR_POS, "Elapsed time:  \t %d days; %d:%d:%d times",
+    mvwprintw(_window, HEADER::ELAPSED_LINE, FIRST_CHAR_POS, "Elapsed time:  \t %ld days; %ld:%ld:%ld times",
               shift_time / SECINDAY, shift_time % SECINDAY / SECINHOUR, shift_time % SECINHOUR / SECINMIN, shift_time % SECINMIN);
     wrefresh(_window);
 }

--- a/analyzers/src/watch/nc_windows/statistics_window.cpp
+++ b/analyzers/src/watch/nc_windows/statistics_window.cpp
@@ -153,14 +153,14 @@ void StatisticsWindow::update(const ProtocolStatistic& d)
         }
         if(canWrite(line))
         {
-            mvwprintw(_window, line - (_scrollOffset.at(_activeProtocol)), FIRST_CHAR_POS + 25, "%d", m);
+            mvwprintw(_window, line - (_scrollOffset.at(_activeProtocol)), FIRST_CHAR_POS + 25, "%zu", m);
         }
         line++;
         for(unsigned int j = _activeProtocol->getGroupBegin(i); j < _activeProtocol->getGroupBegin(i + 1); j++)
         {
             if(canWrite(line))
             {
-                mvwprintw(_window, line - _scrollOffset.at(_activeProtocol), COUNTERS_POS, "%lu ", _statistic[j]);
+                mvwprintw(_window, line - _scrollOffset.at(_activeProtocol), COUNTERS_POS, "%lu ", static_cast<long unsigned int>(_statistic[j]));
                 mvwprintw(_window, line - _scrollOffset.at(_activeProtocol), PERSENT_POS, "%-3.2f%% ",
                           m > 0 ? static_cast<double>(_statistic[j]) / static_cast<double>(m) * 100.0 : 0.0);
             }


### PR DESCRIPTION
A couple mvwprintw() calls result in build errors like:

error: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘time_t’ {aka ‘long int’} [-Werror=format=]

Update these calls to use the correct format specifiers.