### PR TITLE
nfstrace.8: fix reference to libbreakdown.so

### DIFF
--- a/docs/nfstrace.8.in
+++ b/docs/nfstrace.8.in
@@ -328,7 +328,7 @@ procedures and computes standard deviation of latency.
 Usage example:
 .RS 4
 .PP
-.B $ nfstrace \-m stat \-a libreakdown.so
+.B $ nfstrace \-m stat \-a libbreakdown.so
 .RE
 .PP
 Breakdown analyzer produces


### PR DESCRIPTION
Properly specify `libbreakdown.so` in the `nfstrace.8` man page.